### PR TITLE
Fix distribution signature

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -148,7 +148,7 @@ jobs:
           --notes ""
       - name: Upload artifact signatures to GitHub Release
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         # Upload to GitHub Release using the `gh` CLI.
         # `dist/` contains the built packages, and the
         # sigstore-produced signatures and certificates.

--- a/multiauthenticator/__init__.py
+++ b/multiauthenticator/__init__.py
@@ -7,4 +7,4 @@ from multiauthenticator.multiauthenticator import MultiAuthenticator  # noqa
 # __version__ should be updated using tbump, based on configuration in
 # pyproject.toml.
 #
-__version__ = "0.1.0"
+__version__ = "0.1.1.dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jupyterhub-multiauthenticator"
-version = "0.1.0"
+version = "0.1.1.dev"
 authors = [{name = "Samuel Gaist", email = "samuel.gaist@idiap.ch"}]
 description = "Authenticator multiplexer for JupyterHub"
 readme = "README.md"
@@ -99,7 +99,7 @@ show_missing = true
 github_url = "https://github.com/idiap/multiauthenticator"
 
 [tool.tbump.version]
-current = "0.1.0"
+current = "0.1.1.dev"
 regex = '''
     (?P<major>\d+)
     \.


### PR DESCRIPTION
Based on the error returned by the action, update the GITHUB_TOKEN environment variable to GH_TOKEN.