### PR TITLE
Scope GH_TOKEN to steps using

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -129,28 +129,32 @@ jobs:
       contents: write # IMPORTANT: mandatory for making GitHub Releases
       id-token: write # IMPORTANT: mandatory for sigstore
 
-    env:
-      GH_TOKEN: ${{ github.token }}
-
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/
+
       - name: Sign the dists with Sigstore
         uses: sigstore/gh-action-sigstore-python@v1.2.3
         with:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
+
       - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: >-
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
           --notes ""
+
       - name: Upload artifact signatures to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
         # Upload to GitHub Release using the `gh` CLI.
         # `dist/` contains the built packages, and the
         # sigstore-produced signatures and certificates.


### PR DESCRIPTION
This partly reverts the previous change as it avoids passing the secret to all steps and potentially leak it.

Thanks to @webknjaz for pointing it out.