### PR TITLE
Fix redirect issues

### DIFF
--- a/multiauthenticator/multiauthenticator.py
+++ b/multiauthenticator/multiauthenticator.py
@@ -137,7 +137,7 @@ class MultiAuthenticator(Authenticator):
             html.append(
                 f"""
                 <div class="service-login">
-                  <a role="button" class='btn btn-jupyter btn-lg' href='{url}'>
+                  <a role="button" class='btn btn-jupyter btn-lg' href='{url}{{% if next is defined %}}?next={{{{next}}}}{{% endif %}}'>
                     Sign in with {login_service}
                   </a>
                 </div>

--- a/multiauthenticator/multiauthenticator.py
+++ b/multiauthenticator/multiauthenticator.py
@@ -123,7 +123,11 @@ class MultiAuthenticator(Authenticator):
             self._authenticators.append(authenticator)
 
     def get_custom_html(self, base_url):
-        """Re-implementation generating one login button per configured authenticator"""
+        """Re-implementation generating one login button per configured authenticator
+
+        Note: the html generated in this method will be passed through Jinja's template
+        rendering, see the login implementation in JupyterHub's sources.
+        """
 
         html = []
         for authenticator in self._authenticators:

--- a/multiauthenticator/multiauthenticator.py
+++ b/multiauthenticator/multiauthenticator.py
@@ -137,7 +137,7 @@ class MultiAuthenticator(Authenticator):
             html.append(
                 f"""
                 <div class="service-login">
-                  <a role="button" class='btn btn-jupyter btn-lg' href='{url}{{% if next is defined %}}?next={{{{next}}}}{{% endif %}}'>
+                  <a role="button" class='btn btn-jupyter btn-lg' href='{url}{{% if next is defined and next|length %}}?next={{{{next}}}}{{% endif %}}'>
                     Sign in with {login_service}
                   </a>
                 </div>


### PR DESCRIPTION
When using the MutliAuthenticator, if we are redirected to the login page from another page, the redirection back to the original page is broken. The redirection is passed to the authenticator using an argument next. But the authenticator do not forward this next arg to the auth provider leading to a broken redirection.

This PR fixes this by using the context provided during the render of the template to add this missing `next` arg.

Fixes #17 

\cc @sgaist