### PR TITLE
README.md: include JupyterHub in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright © Idiap Research Institute <contact@idiap.ch>
 SPDX-License-Identifier: BSD-3-Clause
 -->
 
-# OAuthAuthenticator + LDAP Autenticator ++... = MultiAuthenticator :heart:
+# JupyterHub OAuthenticator + LDAPAuthenticator ++... = MultiAuthenticator ❤️
 
 The MultiAuthenticator is multiplexer authenticator class that allows to use
 more than one authentication option with JupyterHub.


### PR DESCRIPTION
Fixes some typos, and uses a unicode ❤️ instead of `:heart:` so that it'll display on PyPI https://pypi.org/project/jupyterhub-multiauthenticator/