### PR TITLE
fix: ensure the prefix follows the same convention as the username

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,11 +33,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+        jupyterhub-version:
+          - "3"
+          - "4"
+          - "5"
 
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +51,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install --upgrade pip
+          pip install jupyterhub==${{ matrix.jupyterhub-version }}
           pip install -e ".[test]"
 
       - name: List packages

--- a/multiauthenticator/multiauthenticator.py
+++ b/multiauthenticator/multiauthenticator.py
@@ -81,7 +81,8 @@ class MultiAuthenticator(Authenticator):
 
                 @property
                 def username_prefix(self):
-                    return f"{getattr(self, 'service_name', self.login_service)}{PREFIX_SEPARATOR}"
+                    prefix = f"{getattr(self, 'service_name', self.login_service)}{PREFIX_SEPARATOR}"
+                    return self.normalize_username(prefix)
 
                 async def authenticate(self, handler, data=None, **kwargs):
                     response = await super().authenticate(handler, data, **kwargs)

--- a/multiauthenticator/tests/test_multiauthenticator.py
+++ b/multiauthenticator/tests/test_multiauthenticator.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 """Test module for the MultiAuthenticator class"""
+import jupyterhub
 import pytest
 
 from jinja2 import Template
@@ -11,6 +12,7 @@ from oauthenticator import OAuthenticator
 from oauthenticator.github import GitHubOAuthenticator
 from oauthenticator.gitlab import GitLabOAuthenticator
 from oauthenticator.google import GoogleOAuthenticator
+from packaging.version import Version
 
 from ..multiauthenticator import PREFIX_SEPARATOR
 from ..multiauthenticator import MultiAuthenticator
@@ -275,9 +277,12 @@ def test_username_prefix_checks():
 
     authenticator = multi_authenticator._authenticators[1]
     assert authenticator.check_allowed("test2") == False
-    assert (
-        authenticator.check_allowed("pam2:test2") == True
-    )  # Because allowed_users is empty
+    if Version(jupyterhub.__version__) < Version("5"):
+        assert (
+            authenticator.check_allowed("pam2:test2") == True
+        )  # Because allowed_users is empty
+    else:
+        assert authenticator.check_allowed("pam2:test2") == False
     assert (
         authenticator.check_blocked_users("test2") == False
     )  # Because of missing prefix


### PR DESCRIPTION
## Describe your changes

Authenticators have a normalization function that should also be used on the prefix otherwise there might be issues when dealing with checks as the get_authenticated_user method returns a normalized user while authenticate returns the "raw" user.

This PR fixes that by ensuring the prefix is passed through the same normalization method.

## Issue ticket number and link

Closes #26 