### PR TITLE
feat: pass parent=self to the WrapperAuthenticator

### DIFF
--- a/multiauthenticator/multiauthenticator.py
+++ b/multiauthenticator/multiauthenticator.py
@@ -112,7 +112,9 @@ class MultiAuthenticator(Authenticator):
 
             service_name = authenticator_configuration.pop("service_name", None)
 
-            authenticator = WrapperAuthenticator(**authenticator_configuration)
+            authenticator = WrapperAuthenticator(
+                parent=self, **authenticator_configuration
+            )
 
             if service_name is not None:
                 if PREFIX_SEPARATOR in service_name:


### PR DESCRIPTION
This allows to change the [example configuration](https://github.com/idiap/multiauthenticator?tab=readme-ov-file#configuration) as follows:

```python
from oauthenticator.gitlab import GitLabOAuthenticator
from jupyterhub.auth import PAMAuthenticator

c.GitLabOAuthenticator.client_id: "ZZZZ"
c.GitLabOAuthenticator.client_secret: "AAAAA"
c.GitLabOAuthenticator.oauth_callback_url: "https://jupyterhub.example.com/hub/gitlab/oauth_callback"
c.GitLabOAuthenticator.gitlab_url: "https://gitlab.example.com"

c.MultiAuthenticator.authenticators = [
    (GitLabOAuthenticator, '/gitlab', {}),
    (PAMAuthenticator, "/pam", {"service_name": "PAM"}),
    ...
]

c.JupyterHub.authenticator_class = 'multiauthenticator.multiauthenticator.MultiAuthenticator'
```