### PR TITLE
feat: implement single prefix

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 assert_used:
-  skips: ['multiauthenticator/tests/test_*.py']
+  skips: ['*_test.py', '*test_*.py']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Autoformat: Python code, syntax patterns are modernized
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
+    rev: v3.16.0
     hooks:
       - id: pyupgrade
         args:
@@ -23,7 +23,7 @@ repos:
 
   # Autoformat: Python code
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.1.1
+    rev: v2.3.1
     hooks:
       - id: autoflake
         # args ref: https://github.com/PyCQA/autoflake#advanced-usage
@@ -32,25 +32,25 @@ repos:
 
   # Autoformat: Python code
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
 
   # Autoformat: Python code
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 24.4.2
     hooks:
       - id: black
 
   # Autoformat: markdown, yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
 
   # Misc...
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     # ref: https://github.com/pre-commit/pre-commit-hooks#hooks-available
     hooks:
       - id: end-of-file-fixer
@@ -59,22 +59,30 @@ repos:
 
   # Lint: Python code
   - repo: https://github.com/pycqa/flake8
-    rev: "6.0.0"
+    rev: "7.1.0"
     hooks:
       - id: flake8
 
   # Lint: ensure code does not contain vulnerable patterns
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.7.9
     hooks:
       - id: bandit
         args: [-c, .bandit]
 
   # Ensure project content is properly license and copyrighted
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v2.1.0
+    rev: v4.0.3
     hooks:
       - id: reuse
+
+  # Follow conventional commits standard
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: "v3.3.0"
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []
 
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration
 ci:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ more than one authentication option with JupyterHub.
 
 ```
 $ pip install git+https://github.com/idiap/multiauthenticator
+$ pip install jupyter-multiauthenticator
 ```
 
 ## Configuration
@@ -33,6 +34,9 @@ from oauthenticator.google import GoogleOAuthenticator
 from oauthenticator.gitlab import GitLabOAuthenticator
 from jupyterhub.auth import PAMAuthenticator
 
+class MyPamAutenticator(PAMAuthenticator):
+    login_service = "PAM"
+
 c.MultiAuthenticator.authenticators = [
     (GitHubOAuthenticator, '/github', {
         'client_id': 'XXXX',
@@ -50,7 +54,7 @@ c.MultiAuthenticator.authenticators = [
         "oauth_callback_url": "https://jupyterhub.example.com/hub/gitlab/oauth_callback",
         "gitlab_url": "https://gitlab.example.com"
     }),
-    (PAMAuthenticator, "/pam", {"service_name": "PAM"}),
+    (MyPamAutenticator, "/pam", {}),
 ]
 
 c.JupyterHub.authenticator_class = 'multiauthenticator.multiauthenticator.MultiAuthenticator'

--- a/multiauthenticator/multiauthenticator.py
+++ b/multiauthenticator/multiauthenticator.py
@@ -117,6 +117,9 @@ class MultiAuthenticator(Authenticator):
             )
 
             if service_name is not None:
+                self.log.warning(
+                    "service_name is deprecated, please create a subclass and set the login_service class variable"
+                )
                 if PREFIX_SEPARATOR in service_name:
                     raise ValueError(f"Service name cannot contain {PREFIX_SEPARATOR}")
                 authenticator.service_name = service_name

--- a/multiauthenticator/tests/conftest.py
+++ b/multiauthenticator/tests/conftest.py
@@ -1,0 +1,12 @@
+# Copyright © Idiap Research Institute <contact@idiap.ch>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test Configuration"""
+import pytest
+
+from ..multiauthenticator import PREFIX_SEPARATOR
+
+
+@pytest.fixture(params=[f"test me{PREFIX_SEPARATOR}", f"second{PREFIX_SEPARATOR} test"])
+def invalid_name(request):
+    yield request.param

--- a/multiauthenticator/tests/test_deprecated.py
+++ b/multiauthenticator/tests/test_deprecated.py
@@ -1,0 +1,107 @@
+# Copyright © Idiap Research Institute <contact@idiap.ch>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test module for the deprecated features of the MultiAuthenticator class"""
+import pytest
+
+from jupyterhub.auth import PAMAuthenticator
+from oauthenticator.gitlab import GitLabOAuthenticator
+from oauthenticator.google import GoogleOAuthenticator
+
+from ..multiauthenticator import PREFIX_SEPARATOR
+from ..multiauthenticator import MultiAuthenticator
+
+
+def test_service_name():
+    gitlab_service_name = "gitlab-service"
+    google_service_name = "google-service"
+    authenticators = [
+        (
+            GitLabOAuthenticator,
+            "/gitlab",
+            {
+                "service_name": gitlab_service_name,
+                "client_id": "xxxx",
+                "client_secret": "xxxx",
+                "oauth_callback_url": "http://example.com/hub/gitlab/oauth_callback",
+            },
+        ),
+        (
+            GoogleOAuthenticator,
+            "/google",
+            {
+                "service_name": google_service_name,
+                "client_id": "xxxx",
+                "client_secret": "xxxx",
+                "oauth_callback_url": "http://example.com/hub/othergoogle/oauth_callback",
+            },
+        ),
+    ]
+    MultiAuthenticator.authenticators = authenticators
+
+    multi_authenticator = MultiAuthenticator()
+
+    custom_html = multi_authenticator.get_custom_html("http://example.com")
+
+    assert f"Sign in with {gitlab_service_name}" in custom_html
+    assert f"Sign in with {google_service_name}" in custom_html
+
+
+def test_same_authenticators():
+    MultiAuthenticator.authenticators = [
+        (
+            GoogleOAuthenticator,
+            "/mygoogle",
+            {
+                "service_name": "My Google",
+                "client_id": "yyyyy",
+                "client_secret": "yyyyy",
+                "oauth_callback_url": "http://example.com/hub/mygoogle/oauth_callback",
+            },
+        ),
+        (
+            GoogleOAuthenticator,
+            "/othergoogle",
+            {
+                "service_name": "Other Google",
+                "client_id": "xxxx",
+                "client_secret": "xxxx",
+                "oauth_callback_url": "http://example.com/hub/othergoogle/oauth_callback",
+            },
+        ),
+    ]
+
+    multi_authenticator = MultiAuthenticator()
+    assert len(multi_authenticator._authenticators) == 2
+    assert multi_authenticator.get_custom_html("").count("\n") == 13
+
+    handlers = multi_authenticator.get_handlers("")
+    assert len(handlers) == 6
+    for path, handler in handlers:
+        assert isinstance(handler.authenticator, GoogleOAuthenticator)
+        if "mygoogle" in path:
+            assert handler.authenticator.service_name == "My Google"
+        elif "othergoogle" in path:
+            assert handler.authenticator.service_name == "Other Google"
+        else:
+            raise ValueError(f"Unknown path: {path}")
+
+
+def test_username_prefix_validation_with_service_name(invalid_name, caplog):
+    MultiAuthenticator.authenticators = [
+        (
+            PAMAuthenticator,
+            "/pam",
+            {"service_name": invalid_name, "allowed_users": {"test"}},
+        ),
+    ]
+
+    with pytest.raises(ValueError) as excinfo:
+        MultiAuthenticator()
+
+    assert f"Service name cannot contain {PREFIX_SEPARATOR}" in str(excinfo.value)
+    assert len(caplog.records) == 1
+    assert (
+        caplog.records[0].message
+        == "service_name is deprecated, please create a subclass and set the login_service class variable"
+    )

--- a/multiauthenticator/tests/test_multiauthenticator.py
+++ b/multiauthenticator/tests/test_multiauthenticator.py
@@ -11,7 +11,6 @@ from jupyterhub.auth import PAMAuthenticator
 from oauthenticator import OAuthenticator
 from oauthenticator.github import GitHubOAuthenticator
 from oauthenticator.gitlab import GitLabOAuthenticator
-from oauthenticator.google import GoogleOAuthenticator
 from packaging.version import Version
 
 from ..multiauthenticator import PREFIX_SEPARATOR
@@ -19,8 +18,14 @@ from ..multiauthenticator import MultiAuthenticator
 
 
 class CustomDummyAuthenticator(DummyAuthenticator):
+    login_service = "Dummy"
+
     def normalize_username(self, username):
         return username.upper()
+
+
+class CustomPAMAuthenticator(PAMAuthenticator):
+    login_service = "PAM"
 
 
 def test_different_authenticators():
@@ -43,7 +48,7 @@ def test_different_authenticators():
                 "oauth_callback_url": "http://example.com/hub/github/oauth_callback",
             },
         ),
-        (PAMAuthenticator, "/pam", {"service_name": "PAM"}),
+        (CustomPAMAuthenticator, "/pam", {}),
     ]
 
     multi_authenticator = MultiAuthenticator()
@@ -89,81 +94,6 @@ def test_different_authenticators():
             raise ValueError(f"Unknown authenticator: {authenticator}")
 
 
-def test_same_authenticators():
-    MultiAuthenticator.authenticators = [
-        (
-            GoogleOAuthenticator,
-            "/mygoogle",
-            {
-                "service_name": "My Google",
-                "client_id": "yyyyy",
-                "client_secret": "yyyyy",
-                "oauth_callback_url": "http://example.com/hub/mygoogle/oauth_callback",
-            },
-        ),
-        (
-            GoogleOAuthenticator,
-            "/othergoogle",
-            {
-                "service_name": "Other Google",
-                "client_id": "xxxx",
-                "client_secret": "xxxx",
-                "oauth_callback_url": "http://example.com/hub/othergoogle/oauth_callback",
-            },
-        ),
-    ]
-
-    multi_authenticator = MultiAuthenticator()
-    assert len(multi_authenticator._authenticators) == 2
-    assert multi_authenticator.get_custom_html("").count("\n") == 13
-
-    handlers = multi_authenticator.get_handlers("")
-    assert len(handlers) == 6
-    for path, handler in handlers:
-        assert isinstance(handler.authenticator, GoogleOAuthenticator)
-        if "mygoogle" in path:
-            assert handler.authenticator.service_name == "My Google"
-        elif "othergoogle" in path:
-            assert handler.authenticator.service_name == "Other Google"
-        else:
-            raise ValueError(f"Unknown path: {path}")
-
-
-def test_service_name():
-    gitlab_service_name = "gitlab-service"
-    google_service_name = "google-service"
-    authenticators = [
-        (
-            GitLabOAuthenticator,
-            "/gitlab",
-            {
-                "service_name": gitlab_service_name,
-                "client_id": "xxxx",
-                "client_secret": "xxxx",
-                "oauth_callback_url": "http://example.com/hub/gitlab/oauth_callback",
-            },
-        ),
-        (
-            GoogleOAuthenticator,
-            "/google",
-            {
-                "service_name": google_service_name,
-                "client_id": "xxxx",
-                "client_secret": "xxxx",
-                "oauth_callback_url": "http://example.com/hub/othergoogle/oauth_callback",
-            },
-        ),
-    ]
-    MultiAuthenticator.authenticators = authenticators
-
-    multi_authenticator = MultiAuthenticator()
-
-    custom_html = multi_authenticator.get_custom_html("http://example.com")
-
-    assert f"Sign in with {gitlab_service_name}" in custom_html
-    assert f"Sign in with {google_service_name}" in custom_html
-
-
 def test_extra_configuration():
     allowed_users = {"test_user1", "test_user2"}
 
@@ -179,10 +109,9 @@ def test_extra_configuration():
             },
         ),
         (
-            PAMAuthenticator,
+            CustomDummyAuthenticator,
             "/pam",
             {
-                "service_name": "PAM",
                 "allowed_users": allowed_users,
             },
         ),
@@ -206,8 +135,8 @@ def test_username_prefix():
                 "oauth_callback_url": "http://example.com/hub/gitlab/oauth_callback",
             },
         ),
-        (PAMAuthenticator, "/pam", {"service_name": "PAM"}),
-        (CustomDummyAuthenticator, "/dummy", {"service_name": "Dummy"}),
+        (CustomPAMAuthenticator, "/pam", {}),
+        (CustomDummyAuthenticator, "/dummy", {}),
     ]
 
     multi_authenticator = MultiAuthenticator()
@@ -229,7 +158,7 @@ def test_username_prefix():
 @pytest.mark.asyncio
 async def test_authenticated_username_prefix():
     MultiAuthenticator.authenticators = [
-        (CustomDummyAuthenticator, "/dummy", {"service_name": "Dummy"}),
+        (CustomDummyAuthenticator, "/dummy", {}),
     ]
 
     multi_authenticator = MultiAuthenticator()
@@ -241,23 +170,28 @@ async def test_authenticated_username_prefix():
 
 
 def test_username_prefix_checks():
+    class CustomPAMAuthenticator2(PAMAuthenticator):
+        login_service = "PAM2"
+
+    class CustomDummyAuthenticator2(CustomDummyAuthenticator):
+        login_service = "Dummy2"
+
     MultiAuthenticator.authenticators = [
-        (PAMAuthenticator, "/pam", {"service_name": "PAM", "allowed_users": {"test"}}),
+        (CustomPAMAuthenticator, "/pam", {"allowed_users": {"test"}}),
         (
-            PAMAuthenticator,
+            CustomPAMAuthenticator2,
             "/pam2",
-            {"service_name": "PAM2", "blocked_users": {"test2"}},
+            {"blocked_users": {"test2"}},
         ),
         (
             CustomDummyAuthenticator,
             "/dummy",
-            {"service_name": "Dummy", "allowed_users": {"TEST3"}},
+            {"allowed_users": {"TEST3"}},
         ),
         (
-            CustomDummyAuthenticator,
+            CustomDummyAuthenticator2,
             "/dummy2",
             {
-                "service_name": "Dummy",
                 "allowed_users": {"TEST3"},
                 "blocked_users": {"TEST4"},
             },
@@ -302,36 +236,16 @@ def test_username_prefix_checks():
 
     authenticator = multi_authenticator._authenticators[3]
     assert authenticator.check_allowed("TEST3") == False
-    assert authenticator.check_allowed("DUMMY:TEST3") == True
+    assert authenticator.check_allowed("DUMMY2:TEST3") == True
     assert (
         authenticator.check_blocked_users("TEST3") == False
     )  # Because of missing prefix
     assert (
-        authenticator.check_blocked_users("DUMMY:TEST3") == True
+        authenticator.check_blocked_users("DUMMY2:TEST3") == True
     )  # Because user is not in blocked list
     assert (
-        authenticator.check_blocked_users("DUMMY:TEST4") == False
+        authenticator.check_blocked_users("DUMMY2:TEST4") == False
     )  # Because user is in blocked list
-
-
-@pytest.fixture(params=[f"test me{PREFIX_SEPARATOR}", f"second{PREFIX_SEPARATOR} test"])
-def invalid_name(request):
-    yield request.param
-
-
-def test_username_prefix_validation_with_service_name(invalid_name):
-    MultiAuthenticator.authenticators = [
-        (
-            PAMAuthenticator,
-            "/pam",
-            {"service_name": invalid_name, "allowed_users": {"test"}},
-        ),
-    ]
-
-    with pytest.raises(ValueError) as excinfo:
-        MultiAuthenticator()
-
-    assert f"Service name cannot contain {PREFIX_SEPARATOR}" in str(excinfo.value)
 
 
 def test_username_prefix_validation_with_login_service(invalid_name):
@@ -359,9 +273,9 @@ def test_username_prefix_validation_with_login_service(invalid_name):
 def test_next_handling():
     MultiAuthenticator.authenticators = [
         (
-            PAMAuthenticator,
-            "/pam",
-            {"service_name": "test-service", "allowed_users": {"test"}},
+            CustomDummyAuthenticator,
+            "/dummy",
+            {"allowed_users": {"test"}},
         ),
     ]
 
@@ -371,10 +285,10 @@ def test_next_handling():
     template = Template(html)
 
     with_next = template.render({"next": "/next-destination"})
-    assert "href='pam/login?next=/next-destination'" in with_next
+    assert "href='dummy/login?next=/next-destination'" in with_next
 
     without_next = template.render()
-    assert "href='pam/login'" in without_next
+    assert "href='dummy/login'" in without_next
 
     with_empty_next = template.render({"next": ""})
-    assert "href='pam/login'" in with_empty_next
+    assert "href='dummy/login'" in with_empty_next

--- a/multiauthenticator/tests/test_multiauthenticator.py
+++ b/multiauthenticator/tests/test_multiauthenticator.py
@@ -292,3 +292,21 @@ def test_next_handling():
 
     with_empty_next = template.render({"next": ""})
     assert "href='dummy/login'" in with_empty_next
+
+
+@pytest.mark.parametrize(
+    "prefix,expected", [(None, "DUMMY:TEST"), ("", "TEST"), ("prefix", "PREFIXTEST")]
+)
+@pytest.mark.asyncio
+async def test_prefix(prefix, expected):
+    MultiAuthenticator.username_prefix = prefix
+    MultiAuthenticator.authenticators = [
+        (CustomDummyAuthenticator, "/dummy", {}),
+    ]
+
+    multi_authenticator = MultiAuthenticator()
+    assert len(multi_authenticator._authenticators) == 1
+    user = await multi_authenticator._authenticators[0].get_authenticated_user(
+        None, {"username": "test"}
+    )
+    assert user["name"] == expected


### PR DESCRIPTION
## Describe your changes

This PR implement a new setting for the MultiAuthenticator class: username_prefix.

When set, only this prefix will be used across all Authenticators configured.

It can be useful when there's a need to use an alternate login method while keeping the same username.

**INFO**: the service_name feature is deprecated in favor of subclassing authenticator classes and setting the `login_service` property. It's more verbose however it makes the intention clearer. It will be removed in a future release.

**WARNING: This can have security implications !!!**

If two different users, using each a different login service have the same username returned (e.g. User1 on GitLab gets UserXYZ and User2 on GitHub also get UserXYZ, then they will have access to the same account on the JupyterHub deployment.

## Issue ticket number and link

Closes #27