### PR TITLE
feat: support identifying authenticators with strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,23 @@ This property shall contain a list of tuple with the following content:
 As an example:
 
 ```python
-from oauthenticator.github import GitHubOAuthenticator
-from oauthenticator.google import GoogleOAuthenticator
-from oauthenticator.gitlab import GitLabOAuthenticator
 from jupyterhub.auth import PAMAuthenticator
 
 class MyPamAutenticator(PAMAuthenticator):
     login_service = "PAM"
 
 c.MultiAuthenticator.authenticators = [
-    (GitHubOAuthenticator, '/github', {
+    ('github', '/github', {
         'client_id': 'XXXX',
         'client_secret': 'YYYY',
         'oauth_callback_url': 'https://jupyterhub.example.com/hub/github/oauth_callback'
     }),
-    (GoogleOAuthenticator, '/google', {
+    ('google', '/google', {
         'client_id': 'xxxx',
         'client_secret': 'yyyy',
         'oauth_callback_url': 'https://jupyterhub.example.com/hub/google/oauth_callback'
     }),
-    (GitLabOAuthenticator, '/gitlab', {
+    ('gitlab', '/gitlab', {
         "client_id": "ZZZZ",
         "client_secret": "AAAAA",
         "oauth_callback_url": "https://jupyterhub.example.com/hub/gitlab/oauth_callback",
@@ -57,5 +54,5 @@ c.MultiAuthenticator.authenticators = [
     (MyPamAutenticator, "/pam", {}),
 ]
 
-c.JupyterHub.authenticator_class = 'multiauthenticator.multiauthenticator.MultiAuthenticator'
+c.JupyterHub.authenticator_class = 'multiauthenticator'
 ```

--- a/multiauthenticator/multiauthenticator.py
+++ b/multiauthenticator/multiauthenticator.py
@@ -26,10 +26,10 @@ The same Authenticator class can be used several to support different providers.
 
 """
 try:
-    from importlib.metadata import entry_points
-except ImportError:
     # Python < 3.10
     from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points
 
 from jupyterhub.auth import Authenticator
 from jupyterhub.utils import url_path_join

--- a/multiauthenticator/multiauthenticator.py
+++ b/multiauthenticator/multiauthenticator.py
@@ -6,34 +6,52 @@ Custom Authenticator to use multiple OAuth providers with JupyterHub
 
 Example of configuration:
 
-    from oauthenticator.github import GitHubOAuthenticator
-    from oauthenticator.google import GoogleOAuthenticator
-
     c.MultiAuthenticator.authenticators = [
-        (GitHubOAuthenticator, '/github', {
+        ("github", '/github', {
             'client_id': 'xxxx',
             'client_secret': 'xxxx',
             'oauth_callback_url': 'http://example.com/hub/github/oauth_callback'
         }),
-        (GoogleOAuthenticator, '/google', {
+        ("google", '/google', {
             'client_id': 'xxxx',
             'client_secret': 'xxxx',
             'oauth_callback_url': 'http://example.com/hub/google/oauth_callback'
         }),
-        (PAMAuthenticator, "/pam", {"service_name": "PAM"}),
+        ("pam", "/pam", {"service_name": "PAM"}),
     ]
 
-    c.JupyterHub.authenticator_class = 'oauthenticator.MultiAuthenticator.MultiAuthenticator'
+    c.JupyterHub.authenticator_class = 'multiauthenticator'
 
 The same Authenticator class can be used several to support different providers.
 
 """
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    # Python < 3.10
+    from importlib_metadata import entry_points
+
 from jupyterhub.auth import Authenticator
 from jupyterhub.utils import url_path_join
 from traitlets import List
 from traitlets import Unicode
+from traitlets import import_item
 
 PREFIX_SEPARATOR = ":"
+
+
+def _load_authenticator(authenticator_name):
+    """Load an authenticator from a string
+
+    Looks up authenticators entrypoint registration (e.g. 'github')
+    or full import name ('jupyterhub.auth.PAMAuthenticator').
+
+    Returns the Authenticator subclass.
+    """
+    for entry_point in entry_points(group="jupyterhub.authenticators"):
+        if authenticator_name.lower() == entry_point.name.lower():
+            return entry_point.load()
+    return import_item(authenticator_name)
 
 
 class URLScopeMixin:
@@ -82,6 +100,8 @@ class MultiAuthenticator(Authenticator):
             url_scope_authenticator,
             authenticator_configuration,
         ) in self.authenticators:
+            if isinstance(authenticator_klass, str):
+                authenticator_klass = _load_authenticator(authenticator_klass)
 
             class WrapperAuthenticator(URLScopeMixin, authenticator_klass):
                 url_scope = url_scope_authenticator

--- a/multiauthenticator/tests/test_multiauthenticator.py
+++ b/multiauthenticator/tests/test_multiauthenticator.py
@@ -31,7 +31,7 @@ class CustomPAMAuthenticator(PAMAuthenticator):
 def test_different_authenticators():
     MultiAuthenticator.authenticators = [
         (
-            GitLabOAuthenticator,
+            "gitlab",
             "/gitlab",
             {
                 "client_id": "xxxx",
@@ -40,7 +40,7 @@ def test_different_authenticators():
             },
         ),
         (
-            GitHubOAuthenticator,
+            "oauthenticator.github.GitHubOAuthenticator",
             "/github",
             {
                 "client_id": "xxxx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,16 @@ classifiers = [
 ]
 dependencies = [
     "jupyterhub",
-    "oauthenticator"
+    "oauthenticator",
+    "importlib_metadata>=4.6; python_version < '3.10'",
 ]
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "pytest-asyncio"]
 dev = ["pre-commit", "jupyterhub-multiauthenticator[test]"]
+
+[project.entry-points."jupyterhub.authenticators"]
+multiauthenticator = "multiauthenticator:MultiAuthenticator"
 
 [tool.setuptools]
 packages = ["multiauthenticator"]


### PR DESCRIPTION
enables declarative config without needing Python config files, which will be important to make this convenient in a helm chart config