### PR TITLE
Make oauthenticator be just be a test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,11 @@ classifiers = [
 ]
 dependencies = [
     "jupyterhub",
-    "oauthenticator",
     "importlib_metadata>=4.6; python_version < '3.10'",
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-cov", "pytest-asyncio"]
+test = ["pytest", "pytest-cov", "pytest-asyncio", "oauthenticator"]
 dev = ["pre-commit", "jupyterhub-multiauthenticator[test]"]
 
 [project.entry-points."jupyterhub.authenticators"]


### PR DESCRIPTION
It seems like oauthenticator is just a test dependency and not a direct dependency for using this project, so this PR transitions it to be something installed optionally.